### PR TITLE
reference parent stack

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -11,6 +11,9 @@ metadata:
     alpha.dockerimage-port: 3001
   provider: Red Hat
   supportUrl: https://github.com/devfile-samples/devfile-support#support-information
+parent:
+  id: nodejs
+  registryUrl: "https://registry.devfile.io"
 components:
   - name: outerloop-build
     image:
@@ -22,48 +25,7 @@ components:
   - name: outerloop-deploy
     kubernetes:
       uri: outerloop-deploy.yaml
-  - name: runtime
-    container:
-      image: registry.access.redhat.com/ubi8/nodejs-14:latest
-      memoryLimit: 1024Mi
-      mountSources: true
-      sourceMapping: /project
-      endpoints:
-        - name: http-3000
-          targetPort: 3000
 commands:
-  - id: install
-    exec:
-      component: runtime
-      commandLine: npm install
-      workingDir: /project
-      group:
-        kind: build
-        isDefault: true
-  - id: run
-    exec:
-      component: runtime
-      commandLine: npm start
-      workingDir: /project
-      group:
-        kind: run
-        isDefault: true
-  - id: debug
-    exec:
-      component: runtime
-      commandLine: npm run debug
-      workingDir: /project
-      group:
-        kind: debug
-        isDefault: true
-  - id: test
-    exec:
-      component: runtime
-      commandLine: npm test
-      workingDir: /project
-      group:
-        kind: test
-        isDefault: true
   - id: build-image
     apply:
       component: outerloop-build
@@ -78,3 +40,4 @@ commands:
       group:
         kind: deploy
         isDefault: true
+


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

For issue: https://github.com/devfile/api/issues/715
For the samples, we want to suggest an actual usage, we should reference parent stack instead of copy the parent devfile content inside the main devfile. 