### PR TITLE
remove route name

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -25,11 +25,10 @@ components:
   - name: outerloop-deploy
     attributes:
       deployment/replicas: 1
-      deployment/route: route1
       deployment/cpuLimit: "100m"
       deployment/cpuRequest: 10m
       deployment/memoryLimit: 100Mi
-      deployment/memoryRequest: 10Mi
+      deployment/memoryRequest: 50Mi
       deployment/container-port: 3001
     kubernetes:
       uri: outerloop-deploy.yaml


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

This PR removes the route name from the deploy setting. As discussed we should not suggest any route name for a HAS component if the user brings their own project. also increases the memory request amount for other tools that use both request & limit. 