### PR TITLE
add svc and endpoint definition

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -23,3 +23,16 @@ spec:
             limits:
               memory: "1024Mi"
               cpu: "500m"
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-nodejs-svc
+spec:
+ports:
+  - name: http-3001
+    port: 3001
+    protocol: TCP
+    targetPort: 3001
+selector:
+  app: nodejs-app

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 2.2.0
 metadata:
   name: nodejs
-  version: 2.0.0
+  version: 2.1.0
   displayName: Node.js Runtime
   description: Stack with Node.js 16
   tags: ["NodeJS", "Express", "ubi8"]
@@ -15,14 +15,14 @@ parent:
   id: nodejs
   registryUrl: "https://registry.devfile.io"
 components:
-  - name: outerloop-build
+  - name: image-build
     image:
       imageName: nodejs-image:latest
       dockerfile:
         uri: Dockerfile
         buildContext: .
         rootRequired: false
-  - name: outerloop-deploy
+  - name: kubernetes-deploy
     attributes:
       deployment/replicas: 1
       deployment/cpuLimit: "100m"
@@ -31,14 +31,18 @@ components:
       deployment/memoryRequest: 50Mi
       deployment/container-port: 3001
     kubernetes:
-      uri: outerloop-deploy.yaml
+      uri: deploy.yaml
+      endpoints:
+      - name: http-3001
+        targetPort: 3001
+        path: /
 commands:
   - id: build-image
     apply:
-      component: outerloop-build
+      component: image-build
   - id: deployk8s
     apply:
-      component: outerloop-deploy
+      component: kubernetes-deploy
   - id: deploy
     composite:
       commands:

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -25,11 +25,10 @@ components:
   - name: outerloop-deploy
     attributes:
       deployment/replicas: 1
-      deployment/route: route1
       deployment/cpuLimit: "100m"
       deployment/cpuRequest: 10m
       deployment/memoryLimit: 100Mi
-      deployment/memoryRequest: 10Mi
+      deployment/memoryRequest: 50Mi
       deployment/container-port: 3001
     kubernetes:
       uri: outerloop-deploy.yaml


### PR DESCRIPTION
This PR adds svc and endpoint definition.
removes `outerloop` specific term as we should not "restrict" usage of the sample. 