### PR TITLE
Update nodejs type to match devfile registry

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,12 +1,12 @@
 schemaVersion: 2.2.0
 metadata:
   name: nodejs
-  version: 2.1.0
+  version: 2.1.1
   displayName: Node.js Runtime
   description: Stack with Node.js 16
-  tags: ["NodeJS", "Express", "ubi8"]
-  projectType: "nodejs"
-  language: "nodejs"
+  tags: ["Node.js", "Express", "ubi8"]
+  projectType: "Node.js"
+  language: "JavaScript"
   attributes:
     alpha.dockerimage-port: 3001
   provider: Red Hat

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -25,11 +25,10 @@ components:
   - name: outerloop-deploy
     attributes:
       deployment/replicas: 1
-      deployment/route: route1
       deployment/cpuLimit: "100m"
       deployment/cpuRequest: 10m
       deployment/memoryLimit: 100Mi
-      deployment/memoryRequest: 10Mi
+      deployment/memoryRequest: 50Mi
       deployment/container-port: 3001
     kubernetes:
       uri: outerloop-deploy.yaml


### PR DESCRIPTION
This PR updates the project type, tag and language to match devfile registry: https://github.com/devfile/registry/blob/37d151e4fe493a0f3231f93a4b47c62f5e71fc62/extraDevfileEntries.yaml#L8-L11

this will resolve an issue in stonesoup due to the project type mismatch. 