### PR TITLE
Update readme express version to match the package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nodejs-starter
 
-This is a sample starter project that provides you with a basic Express app and a sample test in a `/test` sub directory. This sample project uses `Express v4.17.x` and enables health checking and application metrics out of the box. You can override or enhance the following endpoints by configuring your own health checks in your application.
+This is a sample starter project that provides you with a basic Express app and a sample test in a `/test` sub directory. This sample project uses `Express v4.18.x` and enables health checking and application metrics out of the box. You can override or enhance the following endpoints by configuring your own health checks in your application.
 
 ## Health checking
 


### PR DESCRIPTION
I've noticed that inside the `package.json` the Express version is 4.18.x while in the Readme file it mentions 4.17.x.

I took the liberty of updating the readme file :)

Related issues: https://github.com/devfile/api/issues/581