### PR TITLE
dockerfile: no longer require package-lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,11 @@ FROM registry.access.redhat.com/ubi8/nodejs-16:latest
 COPY package*.json ./
 
 # Install app dependencies
-RUN npm ci
+RUN \
+  if [ -f package-lock.json ]; then npm ci; \
+  elif [ -f package.json ]; then npm install; \
+  else echo "package.json or package-lock.json not found."; \
+  fi
 
 # Copy the dependencies into a Slim Node docker image
 FROM registry.access.redhat.com/ubi8/nodejs-16-minimal:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ COPY package.json package-lock.json* ./
 # Install app dependencies
 RUN \
   if [ -f package-lock.json ]; then npm ci; \
-  elif [ -f package.json ]; then npm install; \
-  else echo "package.json not found." && exit 1; \
+  else npm install; \
   fi
 
 # Copy the dependencies into a Slim Node docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # Install the app dependencies in a full Node docker image
 FROM registry.access.redhat.com/ubi8/nodejs-16:latest
 
-# Copy package.json and package-lock.json
-COPY package*.json ./
+# Copy package.json, and optionally package-lock.json if it exists
+COPY package.json package-lock.json* ./
 
 # Install app dependencies
 RUN \
   if [ -f package-lock.json ]; then npm ci; \
   elif [ -f package.json ]; then npm install; \
-  else echo "package.json or package-lock.json not found."; \
+  else echo "package.json not found." && exit 1; \
   fi
 
 # Copy the dependencies into a Slim Node docker image


### PR DESCRIPTION
> npm ci requires package-lock.json, so if a sample application being imported doesn’t have it then build is going to fail. 

We want the DevFile to work for as many applications as possible out of the box, so this adds a fallback for the case a project does not have a `package-lock.json`