### PR TITLE
HACDOCS-465: Update README for Node.js code sample.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,22 @@
-# nodejs-starter
+# Creating an application with a Node.js code sample
 
-This is a sample starter project that provides you with a basic Express app and a sample test in a `/test` sub directory. This sample project uses `Express v4.18.x` and enables health checking and application metrics out of the box. You can override or enhance the following endpoints by configuring your own health checks in your application.
+**Note:** The Node.js code sample uses the **8081** HTTP port.
 
-## Health checking
+Before you begin creating an application with this `devfile` code sample, it's helpful to understand the relationship between the `devfile` and `Dockerfile` and how they contribute to your build. You can find these files at the following URLs:
 
-Health-checking enables the cloud platform to determine the `readiness` and `liveness` of your application.
+* [Node.js `devfile.yaml`](https://github.com/nodeshift-starters/devfile-sample/blob/main/devfile.yaml)
+* [Node.js `Dockerfile`](https://github.com/nodeshift-starters/devfile-sample/blob/main/Dockerfile)
 
-These endpoints will be available for you to use:
-
-- Readiness endpoint: http://localhost:3000/ready
-- Liveness endpoint: http://localhost:3000/live
-
-## Application metrics
-
-The [prom-client](https://www.npmjs.com/package/prom-client) module will collect a wide range of resource-centric (CPU, memory) and application-centric (HTTP request responsiveness) metrics from your application, and then expose them as multi-dimensional time-series data through an application endpoint for Prometheus to scrape and aggregate.
-
-This endpoint will be available for you to use:
-
-- Metrics endpoint: http://localhost:3000/metrics
-
-## Dockerfile
-
-For constructing node_modules in the first build stage of Dockerfile, we use `npm ci` to avoid file permissions error. For npm versions greater than 6, `npm install` opens `package-lock.json` in write mode, which is restricted to read mode by ubi images and as a result, node_modules construction ends up with a file permissions error.
+1. The `devfile.yaml` file has an [`image-build` component](https://github.com/nodeshift-starters/devfile-sample/blob/main/devfile.yaml#LL18C2-L24C28) that points to your `Dockerfile`.
+2. The [`docker/Dockerfile`](https://github.com/nodeshift-starters/devfile-sample/blob/main/Dockerfile) contains the instructions you need to build the code sample as a container image.
+3. The `devfile.yaml` [`kubernetes-deploy` component](https://github.com/nodeshift-starters/devfile-sample/blob/main/devfile.yaml#L25-L38) points to a `deploy.yaml` file that contains instructions for deploying the built container image.
+4. The `devfile.yaml` [`deploy` command](https://github.com/nodeshift-starters/devfile-sample/blob/main/devfile.yaml#L40-L53) completes the [outerloop](https://devfile.io/docs/2.2.0/innerloop-vs-outerloop) deployment phase by pointing to the `image-build` and `kubernetes-deploy` components to create your application.
 
 ## License
 
 This stack is licensed under the [EPL 2.0](./LICENSE) license.
+
+### Additional resources
+* For more information about Node.js, see [How do I start with Node.js after I installed it?](https://nodejs.org/en/docs/guides/getting-started-guide).
+* For more information about devfiles, see [Devfile.io](https://devfile.io/).
+* For more information about Dockerfiles, see [Dockerfile reference](https://docs.docker.com/engine/reference/builder/).


### PR DESCRIPTION
[HACDOCS-465](https://issues.redhat.com/browse/HACDOCS-465): After creating content for Spring Boot, Python, and Go code sample readmes, Maysun asked me to update the existing Node.js code sample readme.