### PR TITLE
Enable TLS

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -29,10 +29,10 @@ apiVersion: v1
 metadata:
   name: my-nodejs-svc
 spec:
-ports:
-  - name: http-3001
-    port: 3001
-    protocol: TCP
-    targetPort: 3001
-selector:
-  app: nodejs-app
+  ports:
+    - name: http-3001
+      port: 3001
+      protocol: TCP
+      targetPort: 3001
+  selector:
+    app: nodejs-app

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -31,9 +31,10 @@ components:
     kubernetes:
       uri: deploy.yaml
       endpoints:
-      - name: http-3001
-        targetPort: 3001
-        path: /
+        - name: http-3001
+          targetPort: 3001
+          path: /
+          secure: true
 commands:
   - id: build-image
     apply:


### PR DESCRIPTION
# Description

Set `secure` to `true` to prompt devtools, such as ODC, to create a route with tls enabled.

This should enable TLS on OpenShift for this sample when web console has been patched: https://github.com/devfile/api/issues/1270#issuecomment-1866424653

fixes part of devfile/api#1270