### PR TITLE
Bump schema version to 2.2.2 to match parent stack

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.2.0
+schemaVersion: 2.2.2
 metadata:
   name: nodejs
   version: 3.0.0


### PR DESCRIPTION
# Description

Bumps devfile schema version to `2.2.2` to match Node.js Runtime `nodejs` parent stack: https://github.com/devfile/registry/blob/d1e3f04eeae5b4dca927932db9d25d97688f3a55/stacks/nodejs/2.2.1/devfile.yaml#L1

fixes devfile/api#1590