### PR TITLE
Revert "Bump schema version to 2.2.2 to match parent stack" and reference previous parent version

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -13,6 +13,7 @@ metadata:
   supportUrl: https://github.com/devfile-samples/devfile-support#support-information
 parent:
   id: nodejs
+  version: 2.2.0
   registryUrl: "https://registry.devfile.io"
 components:
   - name: image-build

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.2.2
+schemaVersion: 2.2.0
 metadata:
   name: nodejs
   version: 3.0.0


### PR DESCRIPTION
# Description

Reverts nodeshift-starters/devfile-sample#45 due to the fact ODC only supports up to schema version `2.2.1`: https://github.com/michael-valdron/openshift-console/blob/1b1da7381671226f81d135987e45aa35c827a376/go.mod#L9

To fix schema version mismatch, will reference the previous parent stack version instead.

fixes devfile/api#1590